### PR TITLE
feature/jit-update

### DIFF
--- a/jit/cli.py
+++ b/jit/cli.py
@@ -1,7 +1,8 @@
 import logging
 import os
-
+import subprocess
 import click
+import shutil
 import git
 from rich.logging import RichHandler
 
@@ -88,3 +89,58 @@ def config(repo_name):
         repo = git.Repo(repo_path)
         repo_name = repo.remotes.origin.url.split('/')[-1].replace('.git', '')
     update_config(repo_name)
+
+@jit.command()
+def update():
+    """Fetch the latest changes from the repo and re-install jit."""
+    logging.basicConfig(level=logging.INFO, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
+    log = logging.getLogger("rich")
+
+    repo_path = os.getcwd()
+    repo = git.Repo(repo_path)
+    branch = repo.active_branch
+
+    log.info(f"Current branch: {branch.name}")
+
+    # Check if the branch has an upstream set
+    if not branch.tracking_branch():
+        # Set upstream to the default remote branch (origin/main or origin/master)
+        try:
+            remote_branch = repo.remotes.origin.refs.main
+        except AttributeError:
+            remote_branch = repo.remotes.origin.refs.master
+
+        log.info(f"Setting upstream to {remote_branch}")
+        repo.git.branch('--set-upstream-to', remote_branch, branch.name)
+
+    log.info("Fetching the latest changes from the repository...")
+    repo.git.pull()
+
+    log.info("Re-installing the tool using the Makefile...")
+    env = os.environ.copy()
+    env["COLUMNS"] = str(shutil.get_terminal_size().columns)
+    env["PYTHONUNBUFFERED"] = "1"  # Ensures that Python output is not buffered
+    env["FORCE_COLOR"] = "1"  # Force enable ANSI colors
+
+    process = subprocess.Popen(
+        ["make", "re-install"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env  # Pass the modified environment
+    )
+
+    # Wait for the process to complete and get the return code
+    return_code = process.wait()
+
+    if return_code == 0:
+        # Log stdout and stderr directly after waiting for the process to complete
+        stdout, stderr = process.communicate()
+        log.info(stdout)
+        log.info("jit been updated and re-installed successfully 🎉")
+    else:
+        # Log stderr directly after waiting for the process to complete
+        stdout, stderr = process.communicate()
+        log.error(stderr)
+        log.error("An error occurred while re-installing the tool.")        
+

--- a/jit/utils.py
+++ b/jit/utils.py
@@ -34,7 +34,11 @@ def banner():
     jit = make_purple(jit)
 
     jit_lines = jit.split("\n")
-    terminal_width = os.get_terminal_size().columns 
+    # Attempt to get terminal size, with a fallback
+    try:
+        terminal_width = os.get_terminal_size().columns
+    except OSError:
+        terminal_width = 80  # Fallback width
     banner_width = int(terminal_width / 2)
     if banner_width < 50:
         banner_width = 50

--- a/makefile
+++ b/makefile
@@ -27,7 +27,7 @@ install_jit_editable:
 
 
 ## uninstall_jit: Uninstall the jit package.
-uninstall_jit:
+uninstall:
 	@echo "Uninstalling jit"
 	@bash scripts/uninstall.sh
 	@echo "jit uninstalled successfully"

--- a/makefile
+++ b/makefile
@@ -1,29 +1,33 @@
 .PHONY: setup check_deps install_mac_deps install_jit develop
 
 ## setup: Set up the project.
-setup: check_deps install_jit
+setup: check_deps install_jit welcome
+
+## re-install: reinstall the project without the welcome banner
+re-install: check_deps install_jit
 
 ## develop: Set up the project for development with editable install.
-develop: check_deps install_jit_editable
+develop: check_deps install_jit_editable welcome
 
 ## check_deps: Check for system dependencies like pip3, GitHub CLI, and Ollama.
 check_deps:
 	@bash scripts/check_dependencies.sh
 
+## welcome banner
+welcome:
+	@jit welcome
 
 ## install_jit: Install the jit package.
 install_jit:
 	@echo "Installing jit"
 	@pip3 install .
 	@echo "jit installed successfully"
-	@jit welcome
 
 ## install_jit_editable: Install the jit package in editable mode.
 install_jit_editable:
 	@echo "Installing jit in editable mode"
 	@pip3 install --editable .
 	@echo "jit installed successfully in editable mode"
-	@jit welcome
 
 
 ## uninstall_jit: Uninstall the jit package.

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -49,6 +49,11 @@ else
         echo "llama3 model not found. Do you want to download it now? (y/n)"
         read model_choice
         if [[ "$model_choice" == "y" ]]; then
+            echo "Starting Ollama"
+            bash -c "nohup ollama serve &> /dev/null &"
+            echo "Ollama service started in the background."
+
+            echo "Pulling llama3 model. Strap in, this might take a while."
             ollama pull llama3
             echo "llama3 model downloaded."
         else


### PR DESCRIPTION
## Description
This pull request includes three improvements to our CLI and Makefile: adding an `update` command that fetches the latest changes from the repository and re-installs the JIT tool, adding a terminal-width fallback for the welcome banner, and setting up the project with a `welcome` target.

## Changes
* Added a new CLI command `update` that fetches the latest changes from the repository and re-installs the JIT tool using the Makefile.
* Added a try-except block to the `banner` function to attempt to get the terminal size, with a fallback of 80 columns if an OSError occurs.
* Added a `welcome` target that runs the `jit welcome` command after setting up the project, and added it as a dependency to the `setup` and `develop` targets.