### PR TITLE
feature/jit-update

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+## Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+## Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Additional context
+Add any other context or screenshots about the feature request here.

--- a/jit/cli.py
+++ b/jit/cli.py
@@ -96,51 +96,74 @@ def update():
     logging.basicConfig(level=logging.INFO, format=FORMAT, datefmt="[%X]", handlers=[RichHandler()])
     log = logging.getLogger("rich")
 
-    repo_path = os.getcwd()
-    repo = git.Repo(repo_path)
-    branch = repo.active_branch
+    # Capture the original working directory
+    original_dir = os.getcwd()
 
-    log.info(f"Current branch: {branch.name}")
+    # Get the MY_CURRENT_DIR environment variable
+    repo_path = os.getenv('JIT_DIR')
+    
+    if not repo_path:
+        log.error("JIT_DIR environment variable is not set.")
+        return
 
-    # Check if the branch has an upstream set
-    if not branch.tracking_branch():
-        # Set upstream to the default remote branch (origin/main or origin/master)
-        try:
-            remote_branch = repo.remotes.origin.refs.main
-        except AttributeError:
-            remote_branch = repo.remotes.origin.refs.master
+    try:
+        os.chdir(repo_path)
+        repo = git.Repo(repo_path)
+        branch = repo.active_branch
 
-        log.info(f"Setting upstream to {remote_branch}")
-        repo.git.branch('--set-upstream-to', remote_branch, branch.name)
+        log.info(f"Current branch: {branch.name}")
 
-    log.info("Fetching the latest changes from the repository...")
-    repo.git.pull()
+        # Check if the branch has an upstream set
+        if not branch.tracking_branch():
+            # Set upstream to the default remote branch (origin/main or origin/master)
+            try:
+                remote_branch = repo.remotes.origin.refs.main
+            except AttributeError:
+                remote_branch = repo.remotes.origin.refs.master
 
-    log.info("Re-installing the tool using the Makefile...")
-    env = os.environ.copy()
-    env["COLUMNS"] = str(shutil.get_terminal_size().columns)
-    env["PYTHONUNBUFFERED"] = "1"  # Ensures that Python output is not buffered
-    env["FORCE_COLOR"] = "1"  # Force enable ANSI colors
+            log.info(f"Setting upstream to {remote_branch}")
+            repo.git.branch('--set-upstream-to', remote_branch, branch.name)
 
-    process = subprocess.Popen(
-        ["make", "re-install"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        env=env  # Pass the modified environment
-    )
+        # Fetch the latest changes from the remote
+        repo.remotes.origin.fetch()
 
-    # Wait for the process to complete and get the return code
-    return_code = process.wait()
+        # Check if there are any new changes
+        commits_behind = repo.iter_commits(f'{branch.name}..origin/{branch.name}')
+        if not list(commits_behind):
+            log.info("You are already on the latest version 🤘")
+            return
 
-    if return_code == 0:
-        # Log stdout and stderr directly after waiting for the process to complete
-        stdout, stderr = process.communicate()
-        log.info(stdout)
-        log.info("jit been updated and re-installed successfully 🎉")
-    else:
-        # Log stderr directly after waiting for the process to complete
-        stdout, stderr = process.communicate()
-        log.error(stderr)
-        log.error("An error occurred while re-installing the tool.")        
+        log.info("Fetching the latest changes from the branch...")
+        repo.git.pull()
+
+        log.info("Re-installing the tool using the Makefile...")
+        env = os.environ.copy()
+        env["COLUMNS"] = str(shutil.get_terminal_size().columns)
+        env["PYTHONUNBUFFERED"] = "1"  # Ensures that Python output is not buffered
+        env["FORCE_COLOR"] = "1"  # Force enable ANSI colors
+
+        process = subprocess.Popen(
+            ["make", "update"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env  # Pass the modified environment
+        )
+
+        # Wait for the process to complete and get the return code
+        return_code = process.wait()
+
+        if return_code == 0:
+            # Log stdout and stderr directly after waiting for the process to complete
+            stdout, stderr = process.communicate()
+            log.info(stdout)
+            log.info("jit has been updated and re-installed successfully 🎉")
+        else:
+            # Log stderr directly after waiting for the process to complete
+            stdout, stderr = process.communicate()
+            log.error(stderr)
+            log.error("An error occurred while updating jit.")     
+    finally:
+        # Change back to the original directory
+        os.chdir(original_dir)
 

--- a/makefile
+++ b/makefile
@@ -19,12 +19,17 @@ welcome:
 
 ## install_jit: Install the jit package.
 install_jit:
-	@zsh scripts/install.sh
+	@echo "Installing jit"
+	@pip3 install .
+	@bash scripts/set_dir_env.sh
+	@echo "jit installed successfully"
+
 
 ## install_jit_editable: Install the jit package in editable mode.
 install_jit_editable:
 	@echo "Installing jit in editable mode"
 	@pip3 install --editable .
+	@bash scripts/set_dir_env.sh
 	@echo "jit installed successfully in editable mode"
 
 

--- a/makefile
+++ b/makefile
@@ -3,8 +3,8 @@
 ## setup: Set up the project.
 setup: check_deps install_jit welcome
 
-## re-install: reinstall the project without the welcome banner
-re-install: check_deps install_jit
+## update: update & re-install the project without the welcome banner
+update: check_deps install_jit
 
 ## develop: Set up the project for development with editable install.
 develop: check_deps install_jit_editable welcome
@@ -19,9 +19,7 @@ welcome:
 
 ## install_jit: Install the jit package.
 install_jit:
-	@echo "Installing jit"
-	@pip3 install .
-	@echo "jit installed successfully"
+	@zsh scripts/install.sh
 
 ## install_jit_editable: Install the jit package in editable mode.
 install_jit_editable:

--- a/scripts/set_dir_env.sh
+++ b/scripts/set_dir_env.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/bin/bash
 
 echo "Setting global jit dir environment variable"
 # Get the current directory
@@ -7,18 +7,50 @@ CURRENT_DIR=$(pwd)
 # Define the variable name
 JIT_DIR="JIT_DIR"
 
-# Check if the variable is already defined in the shell configuration file
-if grep -q "$JIT_DIR=" ~/.zshrc; then
-  # If the variable is already defined, update its value
-  sed "s|^$VAR_NAME=.*|$VAR_NAME=$CURRENT_DIR|" ~/.zshrc > ~/.zshrc.tmp && mv ~/.zshrc.tmp ~/.zshrc
+# Check the operating system to determine the shell configuration file
+if [ "$(uname)" == "Darwin" ]; then
+    # macOS
+    CONFIG_FILE="$HOME/.zshrc"
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    # Linux
+    CONFIG_FILE="$HOME/.zshrc"
+elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+    # Windows
+    CONFIG_FILE="$HOME/.bashrc"
 else
-  # If the variable is not defined, add it to the file & export the variable
-  echo "$JIT_DIR=$CURRENT_DIR" >> ~/.zshrc
-  # Export the variable
-  echo "export $JIT_DIR" >> ~/.zshrc
+    echo "Unsupported operating system."
+    exit 1
 fi
 
-# Source the configuration file to apply changes
-source ~/.zshrc
+# Check if Oh My Zsh is installed
+if [ -d "$HOME/.oh-my-zsh" ]; then
+    # Oh My Zsh is installed, switch to it
+    echo "Oh My Zsh is installed. Switching to zsh script..."
+    zsh "$CURRENT_DIR/scripts/set_dir_env_zsh.sh" 
+    exit
+else
+    # Oh My Zsh is not installed
+    echo "Oh My Zsh is not installed. continuing..."
+    # You can choose to install it or take other actions here
+fi
+
+echo "HERE!"
+# Check if the variable is already defined in the shell configuration file
+if grep -q "$JIT_DIR=" "$CONFIG_FILE"; then
+    # If the variable is already defined, update its value
+    sed -i "s|^$JIT_DIR=.*|$JIT_DIR=$CURRENT_DIR|" "$CONFIG_FILE"
+else  
+    # If the variable is not defined, add it to the file & export the variable
+    echo "$JIT_DIR=$CURRENT_DIR" >> "$CONFIG_FILE"
+    # Export the variable (only for Linux and macOS)
+    if [ "$(expr substr $(uname -s) 1 5)" != "MINGW" ]; then
+        echo "export $JIT_DIR" >> "$CONFIG_FILE"
+    fi
+fi
+
+# Source the configuration file to apply changes (only for Linux and macOS)
+if [ "$(expr substr $(uname -s) 1 5)" != "MINGW" ]; then
+    source "$CONFIG_FILE"
+fi
 
 echo "jit install directory has been stored as $JIT_DIR."

--- a/scripts/set_dir_env.sh
+++ b/scripts/set_dir_env.sh
@@ -1,0 +1,24 @@
+#!/bin/zsh
+
+echo "Setting global jit dir environment variable"
+# Get the current directory
+CURRENT_DIR=$(pwd)
+
+# Define the variable name
+JIT_DIR="JIT_DIR"
+
+# Check if the variable is already defined in the shell configuration file
+if grep -q "$JIT_DIR=" ~/.zshrc; then
+  # If the variable is already defined, update its value
+  sed "s|^$VAR_NAME=.*|$VAR_NAME=$CURRENT_DIR|" ~/.zshrc > ~/.zshrc.tmp && mv ~/.zshrc.tmp ~/.zshrc
+else
+  # If the variable is not defined, add it to the file & export the variable
+  echo "$JIT_DIR=$CURRENT_DIR" >> ~/.zshrc
+  # Export the variable
+  echo "export $JIT_DIR" >> ~/.zshrc
+fi
+
+# Source the configuration file to apply changes
+source ~/.zshrc
+
+echo "jit install directory has been stored as $JIT_DIR."

--- a/scripts/set_dir_env_zsh.sh
+++ b/scripts/set_dir_env_zsh.sh
@@ -1,0 +1,17 @@
+#!/bin/zsh
+
+# Check if the variable is already defined in the shell configuration file
+if grep -q "$JIT_DIR=" ~/.zshrc; then
+  # If the variable is already defined, update its value
+  sed "s|^$VAR_NAME=.*|$VAR_NAME=$CURRENT_DIR|" ~/.zshrc > ~/.zshrc.tmp && mv ~/.zshrc.tmp ~/.zshrc
+else
+  # If the variable is not defined, add it to the file & export the variable
+  echo "$JIT_DIR=$CURRENT_DIR" >> ~/.zshrc
+  # Export the variable
+  echo "export $JIT_DIR" >> ~/.zshrc
+fi
+
+# Source the configuration file to apply changes
+source ~/.zshrc
+
+echo "jit install directory has been stored as $JIT_DIR."


### PR DESCRIPTION
## Description
This pull request includes several improvements to the set directory script and makefile. The `update` function now uses an environment variable `JIT_DIR` to determine the repository path and fetches the latest changes from the remote branch before re-installing the tool. Additionally, the install script has been renamed to `set_dir_env`, and a new target has been added to reinstall the project without a welcome banner.

## Changes
* Added support for Windows, Linux, Mac, and Zsh
* Renamed install script to set_dir_env
* Renamed re-install to update
* Updated `update` function to use environment variable `JIT_DIR`
* Added new target to reinstall the project without a welcome banner